### PR TITLE
포스트카드 컴포넌트에 링크가 걸리도록 수정했습니다

### DIFF
--- a/src/components/common/PostCard.tsx
+++ b/src/components/common/PostCard.tsx
@@ -156,13 +156,15 @@ const PostCard = ({ post, hideUser }: PostCardProps) => {
         </div>
       )}
       {post.thumbnail && (
-        <RatioImage
-          src={post.thumbnail}
-          alt="post-thumbnail"
-          widthRatio={1.91}
-          heightRatio={1}
-          className="post-thumbnail"
-        />
+        <Link to={url}>
+          <RatioImage
+            src={post.thumbnail}
+            alt="post-thumbnail"
+            widthRatio={1.91}
+            heightRatio={1}
+            className="post-thumbnail"
+          />
+        </Link>
       )}
       <Link to={url}>
         <h2>{post.title}</h2>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/20786911/74107068-b5391b00-4baf-11ea-9db9-b1d17753b33d.png)
(현재 Velog 메인 페이지)

현재는 포스트의 제목을 클릭해야만 해당 포스트로 이동할 수 있습니다.

![image](https://user-images.githubusercontent.com/20786911/74107043-8327b900-4baf-11ea-81ce-ac32ca86232b.png)

(Medium 서비스의 포스트카드)

![image](https://user-images.githubusercontent.com/20786911/74106839-71451680-4bad-11ea-84a1-d9effaab6f75.png)

(Brunch 서비스의 포스트카드)

![image](https://user-images.githubusercontent.com/20786911/74107021-4d82d000-4baf-11ea-9b97-7e17ea8f5c9a.png)

(Naver 서비스의 포스트카드)

타 블로그 서비스를 둘러 보면 이미지도 링크 영역으로 지정해 유저가 해당 포스트로 쉽게 이동할 수 있도록 하고 있습니다.
(Brunch는 독특하게도 카드 전체를 링크 영역으로 지정하네요.)

Velog도 이미지를 링크 영역으로 지정해 보다 쉽게 해당 포스트를 볼 수 있으면 좋겠습니다.
