### PR TITLE
목차(ToC)를 스크롤 할 수 있도록 변경

### DIFF
--- a/src/components/common/Sticky.tsx
+++ b/src/components/common/Sticky.tsx
@@ -49,7 +49,7 @@ const Sticky: React.FC<StickyProps> = ({ className, top, children }) => {
         top: fixed ? top : undefined,
       }}
     >
-      {children}
+      <div>{children}</div>
     </StickyBlock>
   );
 };

--- a/src/components/post/PostToc.tsx
+++ b/src/components/post/PostToc.tsx
@@ -19,15 +19,21 @@ const Positioner = styled.div`
 `;
 
 const PostTocBlock = styled(Sticky)`
+  overflow-x: hidden;
+  overflow-y: auto;
+  bottom: 0;
   width: 240px;
   margin-left: 5rem;
-  border-left: 2px solid ${palette.gray2};
-  padding-left: 0.75rem;
   padding-top: 0.25rem;
   padding-bottom: 0.25rem;
   color: ${palette.gray6};
   line-height: 1.5;
   font-size: 0.875rem;
+
+  > div {
+    padding-left: 0.75rem;
+    border-left: 2px solid ${palette.gray2};
+  }
 `;
 
 const TocItem = styled.div<{ active: boolean }>`


### PR DESCRIPTION
https://github.com/velopert/velog-client/issues/18

위 이슈로부터 시작한 PR입니다.

ToC 보다 screen의 높이가 작으면 ToC를 스크롤 할 수 있게 합니다.
Sticky 컴포넌트에서 children을 div로 1번 더 감싼 것은 ToC 보다 screen의 높이가 클 때에 border-left도 그만큼 길어지기 때문입니다.
(처음에는 `height: min-content;` 로 시도 했지만 이렇게 하면 스크롤을 못 하는 문제가 있더라구요.)
