### PR TITLE
Fix MathML overflow by setting display to none

### DIFF
--- a/src/components/common/MarkdownRender.tsx
+++ b/src/components/common/MarkdownRender.tsx
@@ -119,6 +119,10 @@ const MarkdownRenderBlock = styled.div`
       background: white;
     }
   }
+
+  .katex-mathml {
+    display: none;
+  }
 `;
 
 function filter(html: string) {


### PR DESCRIPTION
.katex-mathml 때문에 에디터 overflow가 이상하게 발생해서 일단 display: none 으로 고침
이 항목이 왜 있는건지.. 조금 더 분석 후 다른 방향으로 고치게 될지도.