### PR TITLE
Enhance typography for english posts and code tag

### DIFF
--- a/src/components/common/Typography.tsx
+++ b/src/components/common/Typography.tsx
@@ -5,9 +5,9 @@ import media from '../../lib/styles/media';
 
 const TypographyBlock = styled.div`
   font-size: 1.125rem;
-  color: ${palette.gray8};
-  line-height: 1.85;
-  letter-spacing: -0.02em;
+  color: #222426;
+  line-height: 1.7;
+  letter-spacing: -0.004em;
   word-break: keep-all;
   word-wrap: break-word;
   p {
@@ -20,9 +20,10 @@ const TypographyBlock = styled.div`
       font-weight: 400;
     }
     code {
-      background: #e3fff6;
-      padding-left: 0.25em;
-      padding-right: 0.25em;
+      background: rgba(27,31,35,.05);
+      padding: .2em .4em;
+      font-size: 85%;
+      border-radius: 3px;
     }
     a {
       code {

--- a/src/components/common/UserProfile.tsx
+++ b/src/components/common/UserProfile.tsx
@@ -73,7 +73,7 @@ const UserInfo = styled.div`
     line-height: 1.5;
     margin-top: 0.25rem;
     color: ${palette.gray7};
-    letter-spacing: -0.02em;
+    letter-spacing: -0.004em;
   }
 
   ${media.small} {
@@ -86,7 +86,7 @@ const UserInfo = styled.div`
     .description {
       margin-top: 0.5rem;
       font-size: 0.875rem;
-      letter-spacing: -0.02em;
+      letter-spacing: -0.004em;
     }
   }
 `;

--- a/src/components/post/PostHead.tsx
+++ b/src/components/post/PostHead.tsx
@@ -27,7 +27,7 @@ const PostHeadBlock = styled(VelogResponsive)`
     /* font-family: 'Spoqa Han Sans'; */
     font-size: 3rem;
     line-height: 1.5;
-    letter-spacing: -0.02em;
+    letter-spacing: -0.004em;
     margin-top: 0;
     font-weight: 800;
     color: ${palette.gray8};

--- a/src/components/velog/SeriesPostItem.tsx
+++ b/src/components/velog/SeriesPostItem.tsx
@@ -47,7 +47,7 @@ const SeriesPostItemBlock = styled.div<{ edit?: boolean }>`
     align-items: flex-start;
     flex: 1;
     min-width: 0;
-    letter-spacing: -0.02em;
+    letter-spacing: -0.004em;
     height: 6.25rem;
 
     ${media.small} {

--- a/src/components/velog/SeriesPostsTemplate.tsx
+++ b/src/components/velog/SeriesPostsTemplate.tsx
@@ -13,7 +13,7 @@ const SeriesPostsTemplateBlock = styled.div`
     line-height: 1.5;
   }
   h1 {
-    letter-spacing: -0.02em;
+    letter-spacing: -0.004em;
     /* font-family: 'Spoqa Han Sans', -apple-system, BlinkMacSystemFont,
       -apple-system, BlinkMacSystemFont, 'Helvetica Neue', 'Apple SD Gothic Neo',
       arial, 나눔고딕, 'Nanum Gothic', 돋움; */


### PR DESCRIPTION
영문 포스트들이 가독성이 안좋아서 다른 블로그 참고하며 개선함.
- letter-spacing 이 영문 포스트에선 상당히 구림
- line-height가 너무 컸던것 같아서 줄임

코드 블록이 초록색으로 하이라이팅 되어 있는게 이게 코드인지 아닌지 잘 느껴지지 않아서 Github 스타일 참고하며 수정함 (#149)