### PR TITLE
macOS에서의 텍스트 관련 접근성을 향상시켰습니다.

### DIFF
--- a/src/components/auth/AuthEmailSuccess.tsx
+++ b/src/components/auth/AuthEmailSuccess.tsx
@@ -31,7 +31,7 @@ const AuthEmailSuccess: React.FC<AuthEmailSuccessProps> = ({ registered }) => {
   return (
     <AuthEmailSuccessBlock>
       <MdCheck className="icon" />
-      <div className="description">{text} 링크가 이메일로 전송되었습니다.</div>
+      <div className="description">{`${text} 링크가 이메일로 전송되었습니다.`}</div>
     </AuthEmailSuccessBlock>
   );
 };

--- a/src/components/auth/AuthForm.tsx
+++ b/src/components/auth/AuthForm.tsx
@@ -85,7 +85,7 @@ const AuthForm: React.FC<AuthFormProps> = ({
       <div className="upper-wrapper">
         <h2 data-testid="title">{modeText}</h2>
         <section>
-          <h4>이메일로 {modeText}</h4>
+          <h4>{`이메일로 ${modeText}`}</h4>
           {registered !== null ? (
             <AuthEmailSuccess registered={registered} />
           ) : (
@@ -99,7 +99,7 @@ const AuthForm: React.FC<AuthFormProps> = ({
           )}
         </section>
         <section>
-          <h4>소셜 계정으로 {modeText}</h4>
+          <h4>{`소셜 계정으로 ${modeText}`}</h4>
           <AuthSocialButtonGroup currentPath={currentPath} />
         </section>
       </div>

--- a/src/components/common/PostCard.tsx
+++ b/src/components/common/PostCard.tsx
@@ -47,6 +47,7 @@ function PostCard({ post, forHome }: PostCardProps) {
             widthRatio={1.916}
             heightRatio={1}
             src={optimizeImage(post.thumbnail, 640)}
+            alt="post-thumbnail"
           />
         </StyledLink>
       )}
@@ -222,7 +223,7 @@ const Content = styled.div<{ clamp: boolean }>`
       css`
         height: 15.875rem;
       `} */
-  
+
     color: ${palette.gray7};
     margin-bottom: 1.5rem;
   }

--- a/src/components/post/LinkedPostItem.tsx
+++ b/src/components/post/LinkedPostItem.tsx
@@ -128,7 +128,9 @@ const LinkedPostItem: React.FC<LinkedPostItemProps> = ({
         {right ? <MdArrowForward /> : <MdArrowBack />}
       </Circle>
       <Text right={right}>
-        <div className="description">{right ? '다음' : '이전'} 포스트</div>
+        <div className="description">
+          {right ? '다음 포스트' : '이전 포스트'}
+        </div>
         <h3>{linkedPost.title}</h3>
       </Text>
     </LinkedPostItemBlock>

--- a/src/components/post/PostCommentsWrite.tsx
+++ b/src/components/post/PostCommentsWrite.tsx
@@ -63,7 +63,7 @@ const PostCommentsWrite: React.FC<PostCommentsWriteProps> = ({
           </Button>
         )}
         <Button inline onClick={onWrite}>
-          댓글 {edit ? '수정' : '작성'}
+          {edit ? '댓글 수정' : '댓글 작성'}
         </Button>
       </div>
     </PostCommentsWriteBlock>

--- a/src/components/write/AddLink.tsx
+++ b/src/components/write/AddLink.tsx
@@ -101,7 +101,9 @@ const AddLink: React.FC<AddLinkProps> = ({
       >
         <div className="wrapper">
           <div className="top-wrapper">
-            <div className="title">링크 {defaultValue ? '수정' : '등록'}</div>
+            <div className="title">
+              {defaultValue ? '링크 수정' : '링크 등록'}
+            </div>
             {defaultValue && <MdDelete onClick={onDelete} />}
           </div>
           <form onSubmit={onSubmit}>


### PR DESCRIPTION
![변경 전; URL 일부가 텍스트로 나타나고 있다.](https://user-images.githubusercontent.com/20786911/101807395-699d2800-3b58-11eb-8ab1-e863c855afae.png)
![변경 후; post-thumbnail이라는 텍스트가 나타나고 있다.](https://user-images.githubusercontent.com/20786911/101807502-889bba00-3b58-11eb-87fa-3be2e8992963.png)

![변경 전; 텍스트가 일부만 나타나고 있다.](https://user-images.githubusercontent.com/20786911/101807591-a10bd480-3b58-11eb-836a-2192f5d38113.png)
![변경 후; 텍스트가 온전히 나타나고 있다.](https://user-images.githubusercontent.com/20786911/101807962-15467800-3b59-11eb-88c1-eee2eec03b85.png)

이미지의 텍스트 같은 경우는 Velog의 포스트 페이지를 참조해 post-thumbnail로 입력헀지만,
다른 사이트를 보니 포스트의 제목을 넣는 경우도 있네요.
맘에 드시는 쪽으로 선택해주세요!
