### PR TITLE
feat: add keyboard shortcut for markdown editor

### DIFF
--- a/src/components/write/WriteMarkdownEditor.tsx
+++ b/src/components/write/WriteMarkdownEditor.tsx
@@ -196,6 +196,24 @@ export default class WriteMarkdownEditor extends React.Component<
         e.preventDefault();
       }
     }) as any);
+
+    this.codemirror.addKeyMap({
+      // bold
+      'Ctrl-B': (cm) => {
+        const isSurroundedWith = (char: string, str: string) =>
+          str.startsWith(char) && str.endsWith(char);
+
+        const surround = (char: string, str: string) => char + str + char;
+
+        const remove = (char: string, str: string) =>
+          str.slice(char.length, -char.length);
+
+        const toggle = (char: string, str: string) =>
+          isSurroundedWith(char, str) ? remove(char, str) : surround(char, str);
+
+        cm.replaceSelection(toggle('**', cm.getSelection()), 'around');
+      },
+    });
   };
 
   stickToBottomIfNeeded = () => {

--- a/src/components/write/WriteMarkdownEditor.tsx
+++ b/src/components/write/WriteMarkdownEditor.tsx
@@ -66,7 +66,7 @@ const removeHeading = (text: string) => {
   return text.replace(/#{1,6} /, '');
 };
 
-const escapeRegExp = (str: string) =>
+export const escapeRegExp = (str: string) =>
   str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 export const hasSurroundedWith = (char: string, str: string) =>

--- a/src/components/write/WriteMarkdownEditor.tsx
+++ b/src/components/write/WriteMarkdownEditor.tsx
@@ -66,19 +66,22 @@ const removeHeading = (text: string) => {
   return text.replace(/#{1,6} /, '');
 };
 
-export const isSurroundedWith = (char: string, str: string) =>
-  str.startsWith(char) && str.endsWith(char);
+const escapeRegExp = (str: string) =>
+  str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+export const hasSurroundedWith = (char: string, str: string) =>
+  new RegExp(escapeRegExp(char) + '.*' + escapeRegExp(char)).test(str);
 
 export const surround = (char: string, str: string) => char + str + char;
 
 export const remove = (char: string, str: string) =>
-  str.slice(char.length, -char.length);
+  str.replace(new RegExp(escapeRegExp(char), 'g'), '');
 
 export const toggle = (char: string, str: string) =>
-  isSurroundedWith(char, str) ? remove(char, str) : surround(char, str);
+  hasSurroundedWith(char, str) ? remove(char, str) : surround(char, str);
 
 const generateKeyMapFunction = (char: string) => (cm: CodeMirror.Editor) =>
-  cm.replaceSelection(toggle(char, cm.getSelection()), 'around');
+  cm.replaceSelection(toggle(char, cm.getSelection() || '텍스트'), 'around');
 
 function WriterHead({
   hide,

--- a/src/components/write/WriteMarkdownEditor.tsx
+++ b/src/components/write/WriteMarkdownEditor.tsx
@@ -244,6 +244,12 @@ export default class WriteMarkdownEditor extends React.Component<
         cm.replaceSelection(toggle('~~', cm.getSelection()), 'around');
       },
     });
+
+    this.codemirror.on('keydown', (_, event) => {
+      if (event.ctrlKey && event.shiftKey && event.key === 'S') {
+        event.stopPropagation();
+      }
+    });
   };
 
   stickToBottomIfNeeded = () => {

--- a/src/components/write/WriteMarkdownEditor.tsx
+++ b/src/components/write/WriteMarkdownEditor.tsx
@@ -579,10 +579,6 @@ export default class WriteMarkdownEditor extends React.Component<
     const doc = codemirror.getDoc();
 
     const cursor = doc.getCursor();
-    const selection = {
-      start: doc.getCursor('start'),
-      end: doc.getCursor('end'),
-    };
 
     const line = doc.getLine(cursor.line);
 

--- a/src/components/write/WriteMarkdownEditor.tsx
+++ b/src/components/write/WriteMarkdownEditor.tsx
@@ -66,6 +66,20 @@ const removeHeading = (text: string) => {
   return text.replace(/#{1,6} /, '');
 };
 
+export const isSurroundedWith = (char: string, str: string) =>
+  str.startsWith(char) && str.endsWith(char);
+
+export const surround = (char: string, str: string) => char + str + char;
+
+export const remove = (char: string, str: string) =>
+  str.slice(char.length, -char.length);
+
+export const toggle = (char: string, str: string) =>
+  isSurroundedWith(char, str) ? remove(char, str) : surround(char, str);
+
+const generateKeyMapFunction = (char: string) => (cm: CodeMirror.Editor) =>
+  cm.replaceSelection(toggle(char, cm.getSelection()), 'around');
+
 function WriterHead({
   hide,
   children,
@@ -198,51 +212,12 @@ export default class WriteMarkdownEditor extends React.Component<
     }) as any);
 
     this.codemirror.addKeyMap({
-      // bold
-      'Ctrl-B': (cm) => {
-        const isSurroundedWith = (char: string, str: string) =>
-          str.startsWith(char) && str.endsWith(char);
-
-        const surround = (char: string, str: string) => char + str + char;
-
-        const remove = (char: string, str: string) =>
-          str.slice(char.length, -char.length);
-
-        const toggle = (char: string, str: string) =>
-          isSurroundedWith(char, str) ? remove(char, str) : surround(char, str);
-
-        cm.replaceSelection(toggle('**', cm.getSelection()), 'around');
-      },
+      // Bold
+      'Ctrl-B': generateKeyMapFunction('**'),
       // Italic
-      'Ctrl-I': (cm) => {
-        const isSurroundedWith = (char: string, str: string) =>
-          str.startsWith(char) && str.endsWith(char);
-
-        const surround = (char: string, str: string) => char + str + char;
-
-        const remove = (char: string, str: string) =>
-          str.slice(char.length, -char.length);
-
-        const toggle = (char: string, str: string) =>
-          isSurroundedWith(char, str) ? remove(char, str) : surround(char, str);
-
-        cm.replaceSelection(toggle('_', cm.getSelection()), 'around');
-      },
+      'Ctrl-I': generateKeyMapFunction('_'),
       // Strike
-      'Shift-Ctrl-S': (cm) => {
-        const isSurroundedWith = (char: string, str: string) =>
-          str.startsWith(char) && str.endsWith(char);
-
-        const surround = (char: string, str: string) => char + str + char;
-
-        const remove = (char: string, str: string) =>
-          str.slice(char.length, -char.length);
-
-        const toggle = (char: string, str: string) =>
-          isSurroundedWith(char, str) ? remove(char, str) : surround(char, str);
-
-        cm.replaceSelection(toggle('~~', cm.getSelection()), 'around');
-      },
+      'Shift-Ctrl-S': generateKeyMapFunction('~~'),
     });
 
     this.codemirror.on('keydown', (_, event) => {

--- a/src/components/write/WriteMarkdownEditor.tsx
+++ b/src/components/write/WriteMarkdownEditor.tsx
@@ -70,7 +70,7 @@ export const escapeRegExp = (str: string) =>
   str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 export const hasSurroundedWith = (char: string, str: string) =>
-  new RegExp(escapeRegExp(char) + '.*' + escapeRegExp(char)).test(str);
+  new RegExp(escapeRegExp(char) + '[\\s\\S]*' + escapeRegExp(char)).test(str);
 
 export const surround = (char: string, str: string) => char + str + char;
 

--- a/src/components/write/WriteMarkdownEditor.tsx
+++ b/src/components/write/WriteMarkdownEditor.tsx
@@ -82,6 +82,11 @@ export const remove = (char: string, str: string) =>
 export const toggle = (char: string, str: string) =>
   hasSurroundedWith(char, str) ? remove(char, str) : surround(char, str);
 
+const extendCh = (position: CodeMirror.Position, chCount: number) => ({
+  line: position.line,
+  ch: position.ch + chCount,
+});
+
 const generateTextFormatter = (char: string) => (doc: CodeMirror.Doc) => {
   const selection = {
     start: doc.getCursor('start'),
@@ -109,11 +114,6 @@ const generateTextFormatter = (char: string) => (doc: CodeMirror.Doc) => {
 
   doc.replaceSelection(toggle(char, doc.getSelection()), 'around');
 };
-
-const extendCh = (position: CodeMirror.Position, chCount: number) => ({
-  line: position.line,
-  ch: position.ch + chCount,
-});
 
 function WriterHead({
   hide,

--- a/src/components/write/WriteMarkdownEditor.tsx
+++ b/src/components/write/WriteMarkdownEditor.tsx
@@ -66,7 +66,7 @@ const removeHeading = (text: string) => {
   return text.replace(/#{1,6} /, '');
 };
 
-const fallbackString = '텍스트';
+export const fallbackString = '텍스트';
 
 export const escapeRegExp = (str: string) =>
   str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -87,7 +87,8 @@ const extendCh = (position: CodeMirror.Position, chCount: number) => ({
   ch: position.ch + chCount,
 });
 
-const generateTextFormatter = (char: string) => (doc: CodeMirror.Doc) => {
+export const generateTextFormatter =
+  (char: string) => (doc: CodeMirror.Doc) => {
   const selection = {
     start: doc.getCursor('start'),
     end: doc.getCursor('end'),

--- a/src/components/write/WriteMarkdownEditor.tsx
+++ b/src/components/write/WriteMarkdownEditor.tsx
@@ -228,6 +228,21 @@ export default class WriteMarkdownEditor extends React.Component<
 
         cm.replaceSelection(toggle('_', cm.getSelection()), 'around');
       },
+      // Strike
+      'Shift-Ctrl-S': (cm) => {
+        const isSurroundedWith = (char: string, str: string) =>
+          str.startsWith(char) && str.endsWith(char);
+
+        const surround = (char: string, str: string) => char + str + char;
+
+        const remove = (char: string, str: string) =>
+          str.slice(char.length, -char.length);
+
+        const toggle = (char: string, str: string) =>
+          isSurroundedWith(char, str) ? remove(char, str) : surround(char, str);
+
+        cm.replaceSelection(toggle('~~', cm.getSelection()), 'around');
+      },
     });
   };
 

--- a/src/components/write/WriteMarkdownEditor.tsx
+++ b/src/components/write/WriteMarkdownEditor.tsx
@@ -213,6 +213,21 @@ export default class WriteMarkdownEditor extends React.Component<
 
         cm.replaceSelection(toggle('**', cm.getSelection()), 'around');
       },
+      // Italic
+      'Ctrl-I': (cm) => {
+        const isSurroundedWith = (char: string, str: string) =>
+          str.startsWith(char) && str.endsWith(char);
+
+        const surround = (char: string, str: string) => char + str + char;
+
+        const remove = (char: string, str: string) =>
+          str.slice(char.length, -char.length);
+
+        const toggle = (char: string, str: string) =>
+          isSurroundedWith(char, str) ? remove(char, str) : surround(char, str);
+
+        cm.replaceSelection(toggle('_', cm.getSelection()), 'around');
+      },
     });
   };
 

--- a/src/components/write/__tests__/MarkdownEditor.test.tsx
+++ b/src/components/write/__tests__/MarkdownEditor.test.tsx
@@ -76,6 +76,14 @@ describe('MarkdownEditor: keymap', () => {
     expect(hasSurroundedWith('~~', '무~~야호~~b~~cd~~def')).toBe(true);
   });
 
+  test('hasSurroundedWith: 문자열이 multiline 인 경우에도 정상 작동한다', () => {
+    expect(hasSurroundedWith('**', 'a\nbc**d\nd')).toBe(false);
+    expect(hasSurroundedWith('**', '*a\nbc**dd*')).toBe(false);
+
+    expect(hasSurroundedWith('**', 'abc**\ndd**\nee')).toBe(true);
+    expect(hasSurroundedWith('**', '\n**d\nd**')).toBe(true);
+  });
+
   test('surround: 문자열의 앞과 뒤를 char로 감싼 문자열을 반환한다', () => {
     expect(surround('**', 'abcdd')).toBe('**abcdd**');
     expect(surround('_', 'abcddee')).toBe('_abcddee_');

--- a/src/components/write/__tests__/MarkdownEditor.test.tsx
+++ b/src/components/write/__tests__/MarkdownEditor.test.tsx
@@ -1,6 +1,13 @@
 import * as React from 'react';
 import { render, fireEvent } from '@testing-library/react';
-import MarkdownEditor, { MarkdownEditorProps } from '../WriteMarkdownEditor';
+import MarkdownEditor, {
+  escapeRegExp,
+  hasSurroundedWith,
+  MarkdownEditorProps,
+  remove,
+  surround,
+  toggle,
+} from '../WriteMarkdownEditor';
 
 describe('MarkdownEditor', () => {
   const setup = (props: Partial<MarkdownEditorProps> = {}) => {
@@ -42,7 +49,6 @@ describe('MarkdownEditor', () => {
       },
     });
     expect(onChangeTitle).toBeCalledWith('changed');
-    // expect(utils.titleTextarea.value).toBe('changed!');
   });
   it('uses title prop', () => {
     const utils = setup({
@@ -50,17 +56,41 @@ describe('MarkdownEditor', () => {
     });
     expect(utils.titleTextarea.value).toBe('hello world');
   });
+});
 
-  // it('convert editor', () => {
-  //   const onConvert = jest.fn();
-  //   const { getByTestId, getByText } = setup({
-  //     onConvert,
-  //   });
-  //   const convertButton = getByTestId('quillconvert');
-  //   fireEvent.click(convertButton);
-  //   getByText('쉬운 에디터로 전환');
-  //   const confirmButton = getByText('확인');
-  //   fireEvent.click(confirmButton);
-  //   expect(onConvert).toBeCalled();
-  // });
+describe('MarkdownEditor: keymap', () => {
+  test('escapeRegExp: 문자열에 포함된 정규표현식 상 모든 특수문자를 escape한다', () => {
+    `.*+?$^{}()|[]\\`
+      .split('')
+      .forEach((ch) => expect(escapeRegExp(ch)).toBe(`\\${ch}`));
+  });
+
+  test('hasSurroundedWith: char로 둘러싸인 문자열이 하나라도 포함되어 있으면 true를 반환한다', () => {
+    expect(hasSurroundedWith('**', 'abc**dd')).toBe(false);
+    expect(hasSurroundedWith('**', '*abc**dd*')).toBe(false);
+
+    expect(hasSurroundedWith('**', 'abc**dd**ee')).toBe(true);
+    expect(hasSurroundedWith('**', '**dd**')).toBe(true);
+    expect(hasSurroundedWith('**', '****')).toBe(true);
+    expect(hasSurroundedWith('_', 'a_b_cdd_e_e')).toBe(true);
+    expect(hasSurroundedWith('~~', '무~~야호~~b~~cd~~def')).toBe(true);
+  });
+
+  test('surround: 문자열의 앞과 뒤를 char로 감싼 문자열을 반환한다', () => {
+    expect(surround('**', 'abcdd')).toBe('**abcdd**');
+    expect(surround('_', 'abcddee')).toBe('_abcddee_');
+    expect(surround('~~', '')).toBe('~~~~');
+  });
+
+  test('remove: 문자열 내 포함된 char를 모두 제거한다', () => {
+    expect(remove('**', 'abc**dd')).toBe('abcdd');
+    expect(remove('_', 'a_b_cdd_e_e')).toBe('abcddee');
+    expect(remove('~~', '~~~~')).toBe('');
+  });
+
+  test('toggle: char로 둘러싸인 문자열이 하나라도 포함되어 있으면, 문자열 내 포함된 char를 모두 제거한다. 그렇지 않으면 문자열의 앞과 뒤를 char로 감싼 문자열을 반환한다', () => {
+    expect(toggle('**', 'abc**dd**')).toBe('abcdd');
+    expect(toggle('_', 'abcddee')).toBe('_abcddee_');
+    expect(toggle('~~', '')).toBe('~~~~');
+  });
 });


### PR DESCRIPTION
@velopert 님 안녕하세요! 

velog 너무 잘 이용하고 있습니다 ^^

다름이 아니라, velog의 마크다운에디터에서 글을 작성할 때 

선택된 문자열에 대해 Bold, Italic, Strike를 단축키를 누르는 것으로 적용 가능했으면 좋겠다(#260)는 생각이 들어, 적용해보았습니다.

Toolbar의 버튼을 클릭하는 것과 동작을 일치시키기 위해, 

Toolbar 버튼 클릭시의 로직을 별도로 분리하여 함수화하였으며, 

유저가 단축키를 눌렀을 때도 동일한 로직이 실행됩니다. 


### **단축키**는 아래와 같습니다. 

|구분|단축키|
|---|---|
|Bold| Ctrl-B|
|Italic| Ctrl-I|
|Strike| Ctrl-Shift-S(*1, *2)|

*1 Notion의 단축키 구성을 차용했습니다. 
*2 저장기능이 호출되지 않도록 stopPropagation 을 적용하였습니다. 

### 테스트

기존의 많은 부분을 제가 망가뜨리는 건 아닌가 라는 생각이 들어
열심히 테스트를 작성하였는데, 많이 미흡한 것 같습니다.

CodeMirror UI부분를 포함하여 통합 테스트를 작성하고 싶었는데, 
생각대로 잘 되지 않아 CodeMirror 자체에 대한 유닛 테스트만 진행하였습니다.

리뷰 해주시면 감사하겠습니다..!
