### PR TITLE
chore: add og:site_name open graph tag on page

### DIFF
--- a/src/containers/post/PostViewer.tsx
+++ b/src/containers/post/PostViewer.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback, useRef, useState } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import {
   READ_POST,
   SinglePost,
@@ -38,6 +38,7 @@ import optimizeImage from '../../lib/optimizeImage';
 import RelatedPostsForGuest from './RelatedPostsForGuest';
 import HorizontalAd from './HorizontalAd';
 import { useSetShowFooter } from '../../components/velog/VelogPageTemplate';
+import { RootState } from '../../modules';
 
 const UserProfileWrapper = styled(VelogResponsive)`
   margin-top: 16rem;
@@ -98,7 +99,7 @@ const PostViewer: React.FC<PostViewerProps> = ({
   const [likePost, { loading: loadingLike }] = useMutation(LIKE_POST);
   const [unlikePost, { loading: loadingUnlike }] = useMutation(UNLIKE_POST);
   const { showNotFound } = useNotFound();
-  // const userLogo = useSelector((state: RootState) => state.header.userLogo);
+  const userLogo = useSelector((state: RootState) => state.header.userLogo);
   // const velogTitle = useMemo(() => {
   //   if (!userLogo || !userLogo.title) return `${username}.log`;
   //   return userLogo.title;
@@ -326,6 +327,8 @@ const PostViewer: React.FC<PostViewerProps> = ({
     1000 * 60 * 60 * 24 * 365;
 
   const url = `https://velog.io/@${username}/${post.url_slug}`;
+  const siteName = `${username}.log`;
+  const ogSiteName = userLogo?.title ?? siteName;
 
   return (
     <PostViewerProvider prefetchLinkedPosts={prefetchLinkedPosts}>
@@ -335,6 +338,7 @@ const PostViewer: React.FC<PostViewerProps> = ({
           <meta name="description" content={post.short_description} />
         )}
         <link rel="canonical" href={url} />
+        <meta property="og:site_name" content={ogSiteName} />
         <meta property="og:url" content={url} />
         <meta property="og:type" content="article" />
         <meta property="og:title" content={post.title} />


### PR DESCRIPTION
## PR 목적

안녕하세요, [특정 웹 익스텐션](https://chrome.google.com/webstore/detail/cookie-parking/gbpliecdabaekbhmncopnbkfpdippdnl?hl=ko)을 사용하던 중 벨로그에 `site_name` 이라는 og 태그가 존재하지 않아 예쁘게 표시되지 않는 문제를 경험해 작은 개선 PR을 남겨보고자 합니다. 🙂

## 이슈 화면

- 벨로그 사이트의 미리보기를 생성하면,`og:site_name` 태그가 존재하지 않아 사이트 이름이 비어 보입니다.

<img width="280" alt="image" src="https://user-images.githubusercontent.com/26535030/159121894-a2178d90-8120-4539-8405-5835bf0b865a.png">

---

- `og:site_name` 태그가 존재하는 다른 프로젝트의 모습
<img width="280" alt="image" src="https://user-images.githubusercontent.com/26535030/159120916-92ef4483-58b3-410a-a737-5b4cbd24e791.png">

## 작업내용

포스트 페이지에 설정한 블로그명이 존재할 경우에는 블로그 제목을, 블로그명이 존재하지 않을 때는 `{유저네임}.log` 를 갖는 `og:site_name` 태그를 추가했습니다.

## 테스트

로컬호스트에서는 open graph 기반 미리보기가 제공되지 않아 테스트는 수행하지 못했습니다.

- 테스트 시도 1. 원인이 된 웹 익스텐션을 통해 미리보기를 생성해보려 시도했습니다. => 실패

<img width="250" alt="image" src="https://user-images.githubusercontent.com/26535030/159121570-4112f0ac-bb28-4627-9fdb-86da555437ed.png">

- 테스트 시도 2. 페이스북 포스트로 미리보기를 생성해보려 시도했습니다. => 실패

<img width="708" alt="image" src="https://user-images.githubusercontent.com/26535030/159121313-98a977c6-be50-424b-8216-feef1c94d6a1.png">

하지만 제 다른 프로젝트에 [동일한 역할의 코드](https://github.com/C17AN/Merrily-Code/blob/main/pages/post/%5Bslug%5D.tsx#L70)를 추가해본 결과, `og:site_name` 데이터가 제대로 생성되는 것을 확인할 수 있었습니다.

<img width="310" alt="image" src="https://user-images.githubusercontent.com/26535030/159120916-92ef4483-58b3-410a-a737-5b4cbd24e791.png">

---

처음에는 디벨롭 브랜치에 PR을 제출하려 했으나, 마지막 커밋이 작년인 것을 확인해 부득이하게 마스터 브랜치에 직접 PR을 제출했습니다.  
많이 바쁘시겠지만 시간 되실때 확인해주시면 감사드리겠습니다. 🙂

+ 혹시 별도의 PR은 받지 않고 계신다면 코멘트 없이 닫아주셔도 괜찮습니다! 