### PR TITLE
image caption 추가

### DIFF
--- a/src/components/common/MarkdownRender.tsx
+++ b/src/components/common/MarkdownRender.tsx
@@ -5,6 +5,7 @@ import remark from 'remark';
 import slug from 'remark-slug';
 import prismPlugin from '../../lib/remark/prismPlugin';
 import prismThemes from '../../lib/styles/prismThemes';
+import imgCaptionPlugin from '../../lib/remark/imgCaptionPlugin';
 import breaks from 'remark-breaks';
 import Typography from './Typography';
 import embedPlugin from '../../lib/remark/embedPlugin';
@@ -64,8 +65,21 @@ const MarkdownRenderBlock = styled.div`
     max-width: 100%;
     height: auto;
     display: block;
-    margin-top: 1.5rem;
-    margin-bottom: 1.5rem;
+    margin: auto;
+  }
+
+  figure {
+    margin: 3rem 0 3rem 0;
+  }
+
+  figure > figcaption {
+    text-align: center;
+    line-height: 2;
+    font-size: 0.875rem;
+    opacity: 0.8;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
   }
 
   iframe {
@@ -161,6 +175,8 @@ function filter(html: string) {
       'img',
       'del',
       'input',
+      'figure',
+      'figcaption',
 
       ...katexWhitelist.tags,
     ],
@@ -237,6 +253,7 @@ const MarkdownRender: React.FC<MarkdownRenderProps> = ({
         .use(slug)
         .use(prismPlugin)
         .use(embedPlugin)
+        .use(imgCaptionPlugin)
         .use(remark2rehype, { allowDangerousHTML: true })
         .use(raw)
         .use(math)

--- a/src/components/common/Typography.tsx
+++ b/src/components/common/Typography.tsx
@@ -60,16 +60,6 @@ const TypographyBlock = styled.div`
     margin-bottom: 2rem;
   }
 
-  p {
-    img {
-      display: block;
-      margin: 0 auto;
-      max-width: 100%;
-      margin-top: 3rem;
-      margin-bottom: 3rem;
-    }
-  }
-
   h1 {
     font-size: 2.5rem;
   }

--- a/src/lib/remark/imgCaptionPlugin.ts
+++ b/src/lib/remark/imgCaptionPlugin.ts
@@ -1,0 +1,21 @@
+import visit from 'unist-util-visit';
+
+export default function imgCaptionPlugin() {
+  function transformer(tree: any) {
+    const visitor = (node: any) => {
+      try {
+        const figcaptionEle =
+          node && node.alt ? `<figcaption>${node.alt}</figcaption>` : '';
+
+        node.type = 'html';
+        node.value = `<figure><img src="${node.url}"/>${figcaptionEle}</figure>`;
+      } catch (err) {
+        console.log(err);
+      }
+    };
+
+    visit(tree, 'image', visitor);
+  }
+
+  return transformer;
+}


### PR DESCRIPTION
- 이미지 caption 기능이 없는 것 같아서 추가했습니다. (혹시 따로 계획하고 계시거나 다른 이유가 있으시다면 close 부탁드립니다..!)
- 찾아보니 오래된 이슈에 건의된 적이 있는 기능이네요. [issue](https://github.com/velopert/velog-client/issues/189)

# 변경점
  1. imgage caption plugin을 추가했습니다. 마크다운 문법으로 작성된 이미지 태그 들은 `figure` 태그로 감싸지고, 이미지 설명들은 `figcaption` 태그로 감싸져서 이미지를 설명하게 됩니다.
      - `![백준 로고](https://velog.velcdn.com/images/dding-g/post/0071922c-1332-4b33-90e6-d34c61967056/image.png)` 와 같이 사용된 태그들은 caption이 붙습니다.
  3. 기존 `paragraph` 태그 안에 `img` 태그가 들어갔는데, plugin에서 `node.type`을 html 로 주게 되어 더이상 p 태그 안으로 들어가지 않습니다. 기존에 `p > img` 로 처리되고 있던 css들은 `figure`와 `img` 태그에 적절히 나누었습니다.
  4. 마크다운에 `img` 태그를 수동으로 html로 넣는 경우, 이미지 가운데 정렬이 안되는 경우가 있어서 `img` 태그 안에 `margin: auto` 속성을 추가했습니다.

<img width="821" alt="image" src="https://user-images.githubusercontent.com/29707967/174299771-8190acf4-31fe-45e7-a42f-bb51adaa145e.png">

