### PR TITLE
feat : 웹 접근성을 고려한 thumbnail alt 속성 추가 & <html> lang 속성 추가

### DIFF
--- a/src/components/common/PostCard.tsx
+++ b/src/components/common/PostCard.tsx
@@ -54,7 +54,7 @@ function PostCard({ post, forHome, forPost, index }: PostCardProps) {
             widthRatio={1.916}
             heightRatio={1}
             src={optimizeImage(post.thumbnail, 640)}
-            art={`thumbnail of ${getNumberWithOrdinal(index + 1)} post`}
+            alt={`thumbnail of ${getNumberWithOrdinal(index + 1)} post`}
           />
         </StyledLink>
       )}

--- a/src/components/common/PostCard.tsx
+++ b/src/components/common/PostCard.tsx
@@ -53,7 +53,7 @@ function PostCard({ post, forHome, forPost, index }: PostCardProps) {
             widthRatio={1.916}
             heightRatio={1}
             src={optimizeImage(post.thumbnail, 640)}
-            art={`thumbnail of ${getNumberWithOrdinal(index)} post`}
+            art={`thumbnail of ${getNumberWithOrdinal(index + 1)} post`}
           />
         </StyledLink>
       )}

--- a/src/components/common/PostCard.tsx
+++ b/src/components/common/PostCard.tsx
@@ -19,6 +19,7 @@ export type PostCardProps = {
   post: PartialPost;
   forHome?: boolean;
   forPost?: boolean;
+  index: number;
 };
 
 function PostCard({ post, forHome, forPost, index }: PostCardProps) {

--- a/src/components/common/PostCard.tsx
+++ b/src/components/common/PostCard.tsx
@@ -5,7 +5,7 @@ import { ellipsis } from '../../lib/styles/utils';
 import { themedPalette } from '../../lib/styles/themes';
 import { LikeIcon } from '../../static/svg';
 import { PartialPost } from '../../lib/graphql/post';
-import { formatDate } from '../../lib/utils';
+import { formatDate, getNumberWithOrdinal } from '../../lib/utils';
 import { userThumbnail } from '../../static/images';
 import optimizeImage from '../../lib/optimizeImage';
 import SkeletonTexts from './SkeletonTexts';
@@ -21,7 +21,7 @@ export type PostCardProps = {
   forPost?: boolean;
 };
 
-function PostCard({ post, forHome, forPost }: PostCardProps) {
+function PostCard({ post, forHome, forPost, index }: PostCardProps) {
   const url = `/@${post.user.username}/${post.url_slug}`;
 
   const prefetch = usePrefetchPost(post.user.username, post.url_slug);
@@ -53,6 +53,7 @@ function PostCard({ post, forHome, forPost }: PostCardProps) {
             widthRatio={1.916}
             heightRatio={1}
             src={optimizeImage(post.thumbnail, 640)}
+            art={`thumbnail of ${getNumberWithOrdinal(index)} post`}
           />
         </StyledLink>
       )}

--- a/src/components/common/PostCardGrid.tsx
+++ b/src/components/common/PostCardGrid.tsx
@@ -66,6 +66,7 @@ function PostCardGrid({ posts, loading, forHome, forPost }: PostCardGridProps) {
               key={post.id}
               forHome={forHome}
               forPost={forPost}
+              index={i}
             />
           );
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -22,6 +22,12 @@ export const formatDate = (date: string): string => {
   return format(d, 'yyyy년 M월 d일');
 };
 
+export const getNumberWithOrdinal = (num: number) => {
+  const suffix = ["th", "st", "nd", "rd"];
+  const v = num % 100;
+  return num + (suffix[(v - 20) % 10] || suffix[v] || suffix[0]);
+};
+
 export const getScrollTop = () => {
   if (!document.body) return 0;
   const scrollTop = document.documentElement

--- a/src/server/Html.tsx
+++ b/src/server/Html.tsx
@@ -49,7 +49,7 @@ function Html({
   theme,
 }: HtmlProps) {
   return (
-    <html>
+    <html lang="en">
       {/* <head dangerouslySetInnerHTML={{ __html: head }}></head> */}
       <head>
         {helmet.title.toComponent()}


### PR DESCRIPTION
## 변경사항
1. 웹 접근성 향상을 위해 메인 페이지에 보여지는 thumbnail들에 alt 속성을 추가했습니다.
2. html 태그에 lang 속성을 추가했습니다.

유니크한 alt를 위해 싶어 다른 여러가지 방법도 생각해 보았는데,
1. id 값은 유일하지만 의미를 갖고있지 않아 description으로 적절하지않음
2. title은 과도하게 길어질 수 있음
3. username은 프로필 사진의 alt에서 이미 쓰이고있음

그래서 저는 alt="thumbnail of nth post" 방식으로 제안드립니다.
현재 확인중인 포스트가 상위 몇번째로 등록되어 있는지 알수있어 접근성 향상측면에서도 좋은 방법이라고 생각합니다.

---
참고
https://validator.w3.org/nu/?doc=https%3A%2F%2Fvelog.io#l159c25866