### PR TITLE
chore: use setup-node action to cache dependencies

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -11,22 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - name: Get yarn cache
-      id: yarn-cache
-      run: echo "::set-output name=dir::$(yarn cache dir)"
-
-    - uses: actions/cache@v1
+    - uses: actions/setup-node@v3
       with:
-        path: ${{ steps.yarn-cache.outputs.dir }}
-        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-yarn-
-    - name: yarn install
-      uses: borales/actions-yarn@v2.0.0
-      with:
-        cmd: install
-    - name: npm run build:ci
-      run: npm run build:ci
+        cache: 'yarn'
+        cache-dependency-path: |
+          **/yarn.lock
+    - name: Install dependencies
+      run: yarn install --frozen-lockfile
+    - name: Run build:ci
+      run: yarn run build:ci
       env:
         REACT_APP_API_HOST: 'https://v2.velog.io/'
         PUBLIC_URL: 'https://d3v0gm8v6v8olv.cloudfront.net/'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,22 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - name: Get yarn cache
-      id: yarn-cache
-      run: echo "::set-output name=dir::$(yarn cache dir)"
-
-    - uses: actions/cache@v1
+    - uses: actions/setup-node@v3
       with:
-        path: ${{ steps.yarn-cache.outputs.dir }}
-        key: ${{ runner.os }}-yarn-v1-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-yarn-
-    - name: yarn install
-      uses: borales/actions-yarn@v2.0.0
-      with:
-        cmd: install
-    - name: npm run build:ci
-      run: npm run build:ci
+        cache: 'yarn'
+        cache-dependency-path: |
+          **/yarn.lock
+    - name: Install dependencies
+      run: yarn install --frozen-lockfile
+    - name: Run build:ci
+      run: yarn run build:ci
       env:
         REACT_APP_API_HOST: 'https://v2.velog.io/'
         REACT_APP_GRAPHQL_HOST: 'https://v2cdn.velog.io/'


### PR DESCRIPTION
## Description

`actions/setup-node@v3`을 사용하여 Node.js 환경을 설정하고 `yarn` 캐시를 사용하도록 변경하였습니다. 

**AS-IS**

```yml
- name: Get yarn cache
  id: yarn-cache
  run: echo "::set-output name=dir::$(yarn cache dir)"

- uses: actions/cache@v1
  with:
    path: ${{ steps.yarn-cache.outputs.dir }}
    key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
    restore-keys: |
      ${{ runner.os }}-yarn-
- name: yarn install
  uses: borales/actions-yarn@v2.0.0
  with:
    cmd: install
- name: npm run build:ci
  run: npm run build:ci
```

**TO-BE**

```yml
- uses: actions/setup-node@v3
  with:
    cache: 'yarn'
    cache-dependency-path: |
      **/yarn.lock
- name: Install dependencies
  run: yarn install --frozen-lockfile
- name: Run build:ci
  run: yarn run build:ci
```

## References

- [https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows)
- [https://thearchivelog.dev/article/caching-dependencies-to-speed-up-workflows/](https://thearchivelog.dev/article/caching-dependencies-to-speed-up-workflows/)
