### PR TITLE
fix: description colon bug

### DIFF
--- a/src/components/common/FlatPostCard.tsx
+++ b/src/components/common/FlatPostCard.tsx
@@ -187,7 +187,7 @@ const FlatPostCard = ({ post, hideUser }: PostCardProps) => {
       <Link to={url}>
         <h2>{post.title}</h2>
       </Link>
-      <p>{post.short_description}</p>
+      <p>{post.short_description.replace(/&#x3A;/g, ':')}{post.short_description.length === 150 && '...'}</p>
       <div className="tags-wrapper">
         {post.tags.map((tag) => (
           <Tag key={tag} name={tag} link />


### PR DESCRIPTION

<img width="552" alt="image" src="https://github.com/velopert/velog-client/assets/42014299/94e4404b-17a4-43b6-b663-74d3f552660d">

- 위 사진과 같이 내 블로그 목록에서 콜론이 깨져보이는 현상을 수정했습니다.
- `PostCard.tsx`에서는 콜론을 [소스 코드 링크](https://github.com/velopert/velog-client/blob/master/src/components/common/PostCard.tsx#LL64C15-L65C63) 이렇게 처리하고 있는데, `FlatPostCard`에서는 빠져서 추가했습니다.