### PR TITLE
fix: user name validation message

### DIFF
--- a/src/containers/register/RegisterFormContainer.tsx
+++ b/src/containers/register/RegisterFormContainer.tsx
@@ -76,7 +76,7 @@ const RegisterFormContainer: React.FC<RegisterFormContainerProps> = ({
       },
       username: (text: string) => {
         if (!/^[a-z0-9-_]{3,16}$/.test(text)) {
-          return '아이디는 3~16자의 알파벳,숫자,혹은 - _ 으로 이루어져야 합니다.';
+          return '아이디는 3~16자의 알파벳 소문자,숫자,혹은 - _ 으로 이루어져야 합니다.';
         }
       },
       shortBio: (text: string) => {


### PR DESCRIPTION
<img width="1440" alt="image" src="https://github.com/velopert/velog-client/assets/15944970/763e96f1-a82f-4d69-8daf-8b58e5047d3e">

위와 같이 회원가입할 때 알파벳 소문자만 가능하다라는 안내가 없어 클론해서 받아보고 대문자가 안된다는 걸 알았습니다. 다른 분들도 혹시나 저처럼 이유를 몰라 가입을 포기할 수도있지 않을까? 라는 생각에 오픈소스 일 것 같아서 찾아보고 PR 올립니다. 

username validation 메세지의 "알파벳" 이란 단어를 "알파벳 소문자" 로 변경했습니다.