### PR TITLE
fix: show display_name in post head

### DIFF
--- a/src/components/post/PostHead.tsx
+++ b/src/components/post/PostHead.tsx
@@ -127,6 +127,7 @@ export interface PostHeadProps {
   title: string;
   tags: string[];
   username: string;
+  displayName?: string;
   date: string;
   thumbnail: string | null;
   hideThumbnail: boolean;
@@ -151,6 +152,7 @@ export interface PostHeadProps {
 const PostHead: React.FC<PostHeadProps> = ({
   title,
   username,
+  displayName,
   date,
   tags,
   hideThumbnail,
@@ -187,7 +189,9 @@ const PostHead: React.FC<PostHeadProps> = ({
         <SubInfo>
           <div className="information">
             <span className="username">
-              <VLink to={`/@${username}/posts`}>{username}</VLink>
+              <VLink to={`/@${username}/posts`}>
+                {displayName || username}
+              </VLink>
             </span>
             <span className="separator">&middot;</span>
             <span>{formatDate(date)}</span>

--- a/src/containers/post/PostViewer.tsx
+++ b/src/containers/post/PostViewer.tsx
@@ -415,6 +415,7 @@ const PostViewer: React.FC<PostViewerProps> = ({
         title={post.title}
         tags={post.tags}
         username={username}
+        displayName={post.user.profile.display_name}
         date={post.released_at}
         thumbnail={
           post.thumbnail &&


### PR DESCRIPTION
- post head에 displayName이 우선적으로 보이게 변경
- nullable 체크 안하는 이유: 아래 <UserProfile /> 에서 이미`post.user.profile.display_name` 쓰이고 있습니다.