### PR TITLE
fix: EditSeries name style

### DIFF
--- a/src/components/write/PublishSeriesSection.tsx
+++ b/src/components/write/PublishSeriesSection.tsx
@@ -46,7 +46,7 @@ const EditSeries = styled.div`
     padding-right: 1rem;
     background: ${themedPalette.bg_element1};
     font-size: 1.125rem;
-    line-height: 1;
+    line-height: 1.5;
     color: ${themedPalette.text2};
     flex: 1;
   }


### PR DESCRIPTION
시리즈 설정 부분에 y같은 텍스트가 짤리는 현상 수정했습니다.
line-height값은 URL 설정 섹션과 동일하게 주었습니다.

![스크린샷 2024-03-05 135950](https://github.com/velopert/velog-client/assets/92949174/94e6b37e-886e-4975-8c55-d41c7c32c124)


![스크린샷 2024-03-05 140921](https://github.com/velopert/velog-client/assets/92949174/8ecc3c48-2f7a-4e96-ad58-b7d9ab85bff5)
