### PR TITLE
fix: 글 요약(short_description)에 HTML 파편이 노출되는 문제 수정

### DIFF
--- a/src/components/common/FlatPostCard.tsx
+++ b/src/components/common/FlatPostCard.tsx
@@ -13,6 +13,7 @@ import RatioImage from './RatioImage';
 import media from '../../lib/styles/media';
 import PrivatePostLabel from './PrivatePostLabel';
 import optimizeImage from '../../lib/optimizeImage';
+import sanitizeDescription from '../../lib/sanitizeDescription';
 import { LikeIcon } from '../../static/svg';
 import VLink from './VLink';
 
@@ -190,7 +191,7 @@ const FlatPostCard = ({ post, hideUser }: PostCardProps) => {
       <Link to={url}>
         <h2>{post.title}</h2>
       </Link>
-      <p>{post.short_description}</p>
+      <p>{sanitizeDescription(post.short_description)}</p>
       <div className="tags-wrapper">
         {post.tags.map((tag) => (
           <Tag key={tag} name={tag} link />

--- a/src/components/common/PostCard.tsx
+++ b/src/components/common/PostCard.tsx
@@ -8,6 +8,7 @@ import { PartialPost } from '../../lib/graphql/post';
 import { formatDate } from '../../lib/utils';
 import { userThumbnail } from '../../static/images';
 import optimizeImage from '../../lib/optimizeImage';
+import sanitizeDescription from '../../lib/sanitizeDescription';
 import SkeletonTexts from './SkeletonTexts';
 import Skeleton from './Skeleton';
 import { mediaQuery } from '../../lib/styles/media';
@@ -62,7 +63,7 @@ function PostCard({ post, forHome, forPost }: PostCardProps) {
           <h4>{post.title}</h4>
           <div className="description-wrapper">
             <p>
-              {post.short_description.replace(/&#x3A;/g, ':')}
+              {sanitizeDescription(post.short_description)}
               {post.short_description.length === 150 && '...'}
             </p>
           </div>

--- a/src/components/saves/SavedPostItem.tsx
+++ b/src/components/saves/SavedPostItem.tsx
@@ -5,6 +5,7 @@ import { themedPalette } from '../../lib/styles/themes';
 import palette from '../../lib/styles/palette';
 import { formatDate } from '../../lib/utils';
 import { Link } from 'react-router-dom';
+import sanitizeDescription from '../../lib/sanitizeDescription';
 
 export interface SavedPostItemProps {
   post: PartialPost;
@@ -64,7 +65,7 @@ function SavedPostItem({ post, onRemove }: SavedPostItemProps) {
         <Link to={editUrl}>{post.title}</Link>
       </h3>
       <p>
-        <Link to={editUrl}>{post.short_description}</Link>
+        <Link to={editUrl}>{sanitizeDescription(post.short_description)}</Link>
       </p>
       <section>
         <div className="time">{formatDate(post.updated_at)}</div>

--- a/src/components/velog/DraggableSeriesPostList.tsx
+++ b/src/components/velog/DraggableSeriesPostList.tsx
@@ -3,6 +3,7 @@ import styled, { css } from 'styled-components';
 import palette from '../../lib/styles/palette';
 import { SeriesPostPreview } from '../../lib/graphql/series';
 import SeriesPostItem from './SeriesPostItem';
+import sanitizeDescription from '../../lib/sanitizeDescription';
 import {
   DragDropContext,
   Droppable,
@@ -89,7 +90,7 @@ const DraggableSeriesList = ({
                         <SeriesPostItem
                           date={item.post.released_at}
                           title={item.post.title}
-                          description={item.post.short_description}
+                          description={sanitizeDescription(item.post.short_description)}
                           thumbnail={item.post.thumbnail}
                           index={index + 1}
                           urlSlug={item.post.url_slug}

--- a/src/components/velog/SeriesPostList.tsx
+++ b/src/components/velog/SeriesPostList.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import styled from 'styled-components';
 import SeriesPostItem, { SeriesPostItemSkeleton } from './SeriesPostItem';
 import { SeriesPostPreview } from '../../lib/graphql/series';
+import sanitizeDescription from '../../lib/sanitizeDescription';
 
 const SeriesPostListBlock = styled.div`
   margin-top: 4rem;
@@ -31,7 +32,7 @@ const SeriesPostList: React.FC<SeriesPostListProps> = ({
         <SeriesPostItem
           date={seriesPost.post.released_at}
           title={seriesPost.post.title}
-          description={seriesPost.post.short_description}
+          description={sanitizeDescription(seriesPost.post.short_description)}
           thumbnail={seriesPost.post.thumbnail}
           index={reversed ? seriesPosts.length - i : i + 1}
           urlSlug={seriesPost.post.url_slug}

--- a/src/containers/post/RelatedPostsForGuest.tsx
+++ b/src/containers/post/RelatedPostsForGuest.tsx
@@ -13,6 +13,7 @@ import { userThumbnail } from '../../static/images';
 import { Link } from 'react-router-dom';
 import gtag from '../../lib/gtag';
 import optimizeImage from '../../lib/optimizeImage';
+import sanitizeDescription from '../../lib/sanitizeDescription';
 import RelatedPostAd from './RelatedPostAd';
 // import { detectAnyAdblocker } from 'just-detect-adblock';
 
@@ -101,7 +102,7 @@ function RelatedPostsForGuest({
                 <div className="content">
                   <h5>{post.title}</h5>
                   <p>
-                    {post.short_description.replace(/&#x3A;/g, ':')}
+                    {sanitizeDescription(post.short_description)}
                     {post.short_description.length === 150 && '...'}
                   </p>
                 </div>

--- a/src/containers/write/MarkdownEditorContainer.tsx
+++ b/src/containers/write/MarkdownEditorContainer.tsx
@@ -34,6 +34,7 @@ import {
   EDIT_POST,
 } from '../../lib/graphql/post';
 import { escapeForUrl } from '../../lib/utils';
+import sanitizeDescription from '../../lib/sanitizeDescription';
 import { useHistory } from 'react-router';
 import useSaveHotKey from './hooks/useSaveHotkey';
 import embedPlugin from '../../lib/remark/embedPlugin';
@@ -132,7 +133,7 @@ const MarkdownEditorContainer: React.FC<MarkdownEditorContainerProps> = () => {
       .use(strip)
       .process(markdown.replace(/#(.*?)\n/g, ''), (err: any, file: any) => {
         const text = String(file);
-        const sliced = text.replace(/\n/g, '').slice(0, 150);
+        const sliced = sanitizeDescription(text);
         actionCreators.setDefaultDescription(sliced);
         actionCreators.openPublish();
       });

--- a/src/lib/__tests__/sanitizeDescription.test.ts
+++ b/src/lib/__tests__/sanitizeDescription.test.ts
@@ -1,0 +1,72 @@
+import sanitizeDescription from '../sanitizeDescription';
+
+describe('sanitizeDescription', () => {
+  it('returns empty string for empty input', () => {
+    expect(sanitizeDescription('')).toBe('');
+  });
+
+  it('strips HTML tags', () => {
+    expect(sanitizeDescription('<div>hello</div>')).toBe('hello');
+  });
+
+  it('strips HTML tag with attributes', () => {
+    expect(
+      sanitizeDescription('<div style="color: red;">hello world</div>'),
+    ).toBe('hello world');
+  });
+
+  it('decodes common HTML entities', () => {
+    expect(sanitizeDescription('1 &lt; 2 &amp; 3 &gt; 0')).toBe('1 < 2 & 3 > 0');
+  });
+
+  it('decodes hex numeric entities (e.g. &#x3A;)', () => {
+    expect(sanitizeDescription('key&#x3A;value')).toBe('key:value');
+  });
+
+  it('decodes decimal numeric entities', () => {
+    expect(sanitizeDescription('A&#65;B')).toBe('AAB');
+  });
+
+  it('collapses whitespace and trims', () => {
+    expect(sanitizeDescription('  hello\n\nworld   foo  ')).toBe(
+      'hello world foo',
+    );
+  });
+
+  it('does not produce dangling tag fragments when truncating', () => {
+    const raw = 'a'.repeat(148) + '<b>bold</b>';
+    const result = sanitizeDescription(raw);
+    expect(result).not.toMatch(/<[^>]*$/);
+    expect(result.length).toBeLessThanOrEqual(150);
+  });
+
+  it('does not produce dangling entity fragments when truncating', () => {
+    // pre tail = 148 "a"s, then "&lt;xyz" — after decoding "<xyz" would slip in
+    // but we want to test that if something like "&l" survives it gets stripped.
+    const raw = 'a'.repeat(148) + '&lt;end';
+    const result = sanitizeDescription(raw);
+    // after decoding, should be 'a'.repeat(148) + '<end', sliced to 150 = a*148 + '<e'
+    // then dangling-tag strip removes the trailing '<e'
+    expect(result.endsWith('&l')).toBe(false);
+    expect(result).not.toMatch(/<[^>]*$/);
+  });
+
+  it('reproduces the reported bug pattern: `">~<` does not leak', () => {
+    // Simulates a description starting with a malformed tag fragment
+    const raw = '<div style="color:red">~</div> real description text here';
+    const result = sanitizeDescription(raw);
+    expect(result).toBe('~ real description text here');
+    expect(result).not.toContain('">');
+    expect(result).not.toContain('<');
+  });
+
+  it('respects custom limit', () => {
+    const raw = 'abcdefghij';
+    expect(sanitizeDescription(raw, 5)).toBe('abcde');
+  });
+
+  it('leaves a clean short description unchanged', () => {
+    const raw = '이것은 깨끗한 글 요약입니다.';
+    expect(sanitizeDescription(raw)).toBe(raw);
+  });
+});

--- a/src/lib/sanitizeDescription.ts
+++ b/src/lib/sanitizeDescription.ts
@@ -1,0 +1,48 @@
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: '&',
+  lt: '<',
+  gt: '>',
+  quot: '"',
+  apos: "'",
+  nbsp: ' ',
+};
+
+function decodeEntities(input: string): string {
+  return input.replace(/&(#x[0-9a-fA-F]+|#[0-9]+|[a-zA-Z]+);/g, (match, body) => {
+    if (body.startsWith('#x') || body.startsWith('#X')) {
+      const code = parseInt(body.slice(2), 16);
+      return Number.isFinite(code) ? String.fromCodePoint(code) : match;
+    }
+    if (body.startsWith('#')) {
+      const code = parseInt(body.slice(1), 10);
+      return Number.isFinite(code) ? String.fromCodePoint(code) : match;
+    }
+    const named = NAMED_ENTITIES[body.toLowerCase()];
+    return named ?? match;
+  });
+}
+
+function stripDanglingEntity(input: string): string {
+  return input.replace(/&(#x?[0-9a-fA-F]*|[a-zA-Z]*)$/, '');
+}
+
+function stripDanglingTag(input: string): string {
+  const lastOpen = input.lastIndexOf('<');
+  const lastClose = input.lastIndexOf('>');
+  if (lastOpen > lastClose) {
+    return input.slice(0, lastOpen);
+  }
+  return input;
+}
+
+export function sanitizeDescription(raw: string, limit = 150): string {
+  if (!raw) return '';
+  const withoutTags = raw.replace(/<[^>]*>/g, '');
+  const decoded = decodeEntities(withoutTags);
+  const collapsed = decoded.replace(/\s+/g, ' ').trim();
+  if (collapsed.length <= limit) return collapsed;
+  const sliced = collapsed.slice(0, limit);
+  return stripDanglingTag(stripDanglingEntity(sliced));
+}
+
+export default sanitizeDescription;

--- a/src/modules/write.ts
+++ b/src/modules/write.ts
@@ -1,5 +1,6 @@
 import { deprecated } from 'typesafe-actions';
 import { createReducer, updateKey } from '../lib/utils';
+import sanitizeDescription from '../lib/sanitizeDescription';
 
 const { createStandardAction } = deprecated;
 
@@ -203,7 +204,7 @@ const write = createReducer(
         ...state,
         title,
         tags,
-        description: description.slice(0, 150),
+        description: sanitizeDescription(description),
         urlSlug,
         isPrivate,
         isTemp: isTemp || false,


### PR DESCRIPTION
## 문제점

`velog.io/@username` 같은 유저 글 목록이나 시리즈/관련 글 카드에서 글 요약 부분에 `">~<`, `">~&l` 같은 HTML 파편이 그대로 보이는 문제가 있었습니다.

<img width="150" alt="image" src="https://github.com/user-attachments/assets/94ca8b83-fbb4-4aff-b303-fb287321bb01" />
<img width="150" alt="image" src="https://github.com/user-attachments/assets/43379fea-e887-4129-ae6f-7caf08cbe324" />

## 원인

1. 글 발행 시 `MarkdownEditorContainer`에서 `strip-markdown`만으로는 본문 내 raw HTML(`<div style="...">`, `<iframe>` 등)이 완전히 제거되지 않아 `short_description`에 HTML 조각이 섞인 채 저장됩니다.                                                                                                                                       
2. 이후 `.slice(0, 150)`으로 문자 단위로 자르기 때문에 HTML 태그나 엔티티(`&lt;` 등) 중간이 잘려 `...<`, `...&l` 같은 파편이 남습니다.                                                                                                                         
3. 렌더 지점(`FlatPostCard`, `PostCard` 등)은 `{post.short_description}`을 그대로 표시하기 때문에 파편이 UI에 그대로 노출됩니다.

## 변경사항

### 유틸 추가

- `src/lib/sanitizeDescription.ts` 신규 추가
    - HTML 태그 제거 → 엔티티 디코딩 → 공백 정리 → 150자 safe truncate
    - 잘린 뒤 남은 dangling 태그/엔티티 조각 제거
- 단위 테스트 12개로 동작 검증 (실제 버그 패턴 재현 테스트 포함)

### 적용
  - `MarkdownEditorContainer.onPublish`: `sanitizeDescription` 적용
  - `modules/write.ts` `PREPARE_EDIT`: 기존 글 편집 로드 시에도 정제. 앞으로 저장되는 데이터는 깨끗하게 들어갑니다.

### 호환성
  이미 저장된 과거 글들을 위해 렌더 시점에도 정제를 적용
  - `FlatPostCard`, `PostCard`
  - `SavedPostItem`
  - `SeriesPostList`, `DraggableSeriesPostList`
  - `RelatedPostsForGuest`

기존에 산재해 있던 `post.short_description.replace(/&#x3A;/g, ':')` 임시 치환 로직도 유틸로 통합했습니다.

## 참고                                                                                                                                                                                        
  - 사용자 직접 입력 필드(`CHANGE_DESCRIPTION`)에는 정제를 적용하지 않았습니다.
    입력 중 타이핑 경험을 해치지 않기 위함이며, 발행 시점에 한 번 더 정제됩니다.
  - 서버 측 DB 마이그레이션은 포함되지 않았습니다. 렌더 시점 정제로
    사용자 경험은 즉시 개선되고, 편집·재저장을 거치면 DB 데이터도 점진적으로 정리됩니다.