### PR TITLE
feat: use vlink for series label

### DIFF
--- a/src/components/velog/SeriesPostsTemplate.tsx
+++ b/src/components/velog/SeriesPostsTemplate.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef } from 'react';
 import styled from 'styled-components';
 import { themedPalette } from '../../lib/styles/themes';
 import SkeletonTexts from '../common/SkeletonTexts';
+import VLink from '../common/VLink';
 
 const SeriesPostsTemplateBlock = styled.div`
   & > label {
@@ -34,6 +35,7 @@ const Separator = styled.div`
 `;
 
 export interface SeriesPostsTemplateProps {
+  username: string;
   name: string;
   nextName: string;
   editing: boolean;
@@ -43,6 +45,7 @@ export interface SeriesPostsTemplateProps {
 const SeriesPostsTemplate: React.FC<SeriesPostsTemplateProps> = ({
   children,
   editing,
+  username,
   name,
   onInput,
 }) => {
@@ -54,7 +57,9 @@ const SeriesPostsTemplate: React.FC<SeriesPostsTemplateProps> = ({
   }, [editing]);
   return (
     <SeriesPostsTemplateBlock>
-      <label>시리즈</label>
+      <label>
+        <VLink to={`/@${username}/series`}>시리즈</VLink>
+      </label>
       <h1
         contentEditable={editing}
         ref={titleRef}

--- a/src/components/velog/__tests__/SeriesPostsTemplate.test.tsx
+++ b/src/components/velog/__tests__/SeriesPostsTemplate.test.tsx
@@ -7,6 +7,7 @@ import SeriesPostsTemplate, {
 describe('SeriesPostsTemplate', () => {
   const setup = (props: Partial<SeriesPostsTemplateProps> = {}) => {
     const initialProps: SeriesPostsTemplateProps = {
+      username: 'velopert',
       name: '시리즈 이름',
     };
     const utils = render(<SeriesPostsTemplate {...initialProps} {...props} />);

--- a/src/containers/velog/SeriesPosts.tsx
+++ b/src/containers/velog/SeriesPosts.tsx
@@ -137,6 +137,7 @@ const SeriesPosts: React.FC<SeriesPostsProps> = ({ username, urlSlug }) => {
 
   return (
     <SeriesPostsTemplate
+      username={username}
       name={data.series.name}
       nextName={nextName}
       editing={editing}


### PR DESCRIPTION
## 변경 사항

시리즈 상세 페이지 상단의 '시리즈' 라벨을 클릭하면 해당 유저의
시리즈 목록(`/@{username}/series`)으로 이동하도록 링크를 추가했습니다.

기존에는 라벨이 밑줄과 포인트 컬러로 강조되어 있어 클릭 가능해 보이지만
실제로는 아무 동작도 하지 않았습니다.

## 구현

`feat: use vlink for tag`(8cf9ab2)와 동일하게 `VLink`를 사용했습니다.
v2의 `/@{username}/series` 경로는 `UserPage`에서 v3의 `/posts`로
리다이렉트되기 때문에, `react-router`의 `Link` 대신 v3 시리즈 목록을
직접 가리키도록 했습니다. 시리즈 삭제 후 리다이렉트 경로
(`SeriesPosts.tsx`)와 동일한 방식입니다.